### PR TITLE
Updated Alt-K: Reblur feature (Chrome Only)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Packages #
+############
+*.rar
+*.tar
+*.zip
+
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/chrome/background.js
+++ b/chrome/background.js
@@ -5,16 +5,21 @@
  *   - On extension installation, create default local storage settings
  *   - On extension load, add listeners for key commands & sends appropriate messages to tab.js
         - Listens for "Alt+L", if detected, sends "reverse_status" message to tab.js
-        - Listens for "Alt+K", if detected, sends "unblur_selected" message to tab.js
+        - Listens for "Alt+K", if detected, sends "toggle_selected" message to tab.js
  */
 
 
-/* On extension installation, create default local storage settings */
+/* On extension installation, create default local storage settings. On extension update, display newtab with latest changes (update.html). */
 chrome.runtime.onInstalled.addListener (function(obj) {
   if (obj.reason === "install") {
     const settings = {'type': 'settings', 'status': true, 'images': true, 'videos': true, 'iframes': true, 'blurAmt': 20, 'grayscale': true, 'bgImages': true}
     chrome.storage.sync.set({'settings': settings})
   }
+
+  if (obj.reason === 'update') {
+    chrome.tabs.create({url: chrome.extension.getURL('update.html')});
+  }
+
 });
 
 
@@ -25,9 +30,9 @@ chrome.commands.onCommand.addListener(function (command) {
     		chrome.tabs.sendMessage(tabs[0].id, {"message": "reverse_status"});  
 		});
     }
-    if (command === "unblur_selected") {
+    if (command === "toggle_selected") {
     	chrome.tabs.query({active: true, currentWindow: true}, function(tabs){
-    		chrome.tabs.sendMessage(tabs[0].id, {"message": "reveal_selected"});  
+    		chrome.tabs.sendMessage(tabs[0].id, {"message": "toggle_selected"});  
 		});
     }
 });

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Tahir",
   "description": "Avoid haram images & videos on the Internet.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "permissions": [
   	"storage"
   ],

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -19,11 +19,11 @@
         },
         "description": "Reverse blur state"
     },
-    "unblur_selected": {
+    "toggle_selected": {
         "suggested_key": {
             "default": "Alt+K"
         },
-        "description": "Unblur selected image"
+        "description": "Unblur/reblur selected image"
     }
 },
   "background": {

--- a/chrome/popup.html
+++ b/chrome/popup.html
@@ -6,7 +6,7 @@
     <style media="screen" type="text/css">
 
       .popup {
-        min-width:300px;
+        min-width:320px;
       }
 
       .title {
@@ -126,7 +126,7 @@
 
     <div class="shortcuts">
       <div><span>Alt+L: turn on / off </span></div>
-      <div><span>Alt+K: over image to selectively unblur (close this first)</span></div>
+      <div><span>Alt+K: over image to selectively unblur/reblur (close this first)</span></div>
     </div>
     
   </body>

--- a/chrome/popup.js
+++ b/chrome/popup.js
@@ -45,7 +45,7 @@ function initPopup () {
 /* getSettings - (1) Gets local storage settings, (2) sets local settings var to local storage settings, (3) resolves promise when complete  */
 function getSettings () {
   return new Promise(function(resolve) {
-      chrome.storage.sync.get(['settings'], function(storage) {
+    chrome.storage.sync.get(['settings'], function(storage) {
       settings = storage.settings
       resolve()
     });   

--- a/chrome/update.html
+++ b/chrome/update.html
@@ -1,0 +1,44 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Tahir - Update (1.0.4)</title>
+    <style media="screen" type="text/css">
+    	.main { 
+    		width: 50%;
+    		margin-left: 25%;
+    		border: 1px solid black;
+    		padding: 10px;
+    		font-size: 13px;
+    	}
+    
+    	.title {
+    		text-align: center;
+    		margin-top: 20px;
+    	}
+
+    	.message {
+    		margin-bottom: 15px;
+    	}
+
+    	.changelog {
+    		margin-bottom: 100px;
+    	}
+
+    </style> 
+  </head>
+  <body>
+
+  	<div class="main">
+  		<h1 class="title">Tahir is updated! - Version 1.0.4</h1>
+  		<div class="message">As salamu alaykum wa rahmatullah, <br/><br/> Below are the latest improvements for Tahir. We pray they are of benefit. If you like Tahir, please share with others (shareable links: <a href="https://twitter.com/intent/tweet?text=Check%20out%20Tahir!%20A%20chrome%20and%20firefox%20extension%20that%20automatically%20%22lowers%20your%20gaze%22%20on%20the%20web:%20https://chrome.google.com/webstore/detail/tahir/ihmoammkfbdpokfiiifajdkfglmfejca" target="_blank">Twitter</a>, <a href="https://www.facebook.com/sharer/sharer.php?u=https://chrome.google.com/webstore/detail/tahir/ihmoammkfbdpokfiiifajdkfglmfejca" target="_blank">Facebook</a>). You will get reward for the haram images prevented through your shares, iA. For support or comments, send us a message at dev@fushatech.com. To contribute to the code, see our <a href="https://github.com/fushatech/tahir" target="_blank">github</a>. <br/><br/> May Allah give us all tawfiq to protect our eyes from the impermissible. </div> 
+  		<hr />
+  		<h3>Changelog:</h3>
+  		<ul class="changelog">
+  			<li>Tahir is now <a href="https://addons.mozilla.org/en-US/firefox/addon/tahir/" target="_blank">available on Firefox.</a> (JAK to brother @sh4hids)</li>
+  			<li>Alt+K now unblurs <strong>& reblurs an image</strong>. After unbluring an image, press Alt+K again to reblur it. </li>
+  			<li>Several technical improvements.</li>
+  		</ul>
+   	</div>
+
+  </body>
+</html>


### PR DESCRIPTION
- Alt-K now reblurs
- Alt-K method to unblur improved
- Alt-K adds unblur/reblur to entire hover sub-tree
- Updated method to blur BG images (now blurs, instead of setting background-color to gray)
- Created "update.html" which is opened in a new-tab on extension update. 
- Added .gitignore file
- Updated manifest.json versioning to 1.0.4