### PR TITLE
Added Alt+K reblur to firefox

### DIFF
--- a/firefox/background.js
+++ b/firefox/background.js
@@ -5,16 +5,21 @@
  *   - On extension installation, create default local storage settings
  *   - On extension load, add listeners for key commands & sends appropriate messages to tab.js
         - Listens for "Alt+L", if detected, sends "reverse_status" message to tab.js
-        - Listens for "Alt+K", if detected, sends "unblur_selected" message to tab.js
+        - Listens for "Alt+K", if detected, sends "toggle_selected" message to tab.js
  */
 
 
-/* On extension installation, create default local storage settings */
+/* On extension installation, create default local storage settings. On extension update, display newtab with latest changes (update.html). */
 browser.runtime.onInstalled.addListener (function(obj) {
   if (obj.reason === "install") {
     const settings = {'type': 'settings', 'status': true, 'images': true, 'videos': true, 'iframes': true, 'blurAmt': 20, 'grayscale': true, 'bgImages': true}
     browser.storage.sync.set({'settings': settings})
   }
+
+  if (obj.reason === 'update') {
+    browser.tabs.create({url: browser.extension.getURL('update.html')});
+  }
+
 });
 
 
@@ -25,9 +30,9 @@ browser.commands.onCommand.addListener(function (command) {
     		browser.tabs.sendMessage(tabs[0].id, {"message": "reverse_status"});
 		});
     }
-    if (command === "unblur_selected") {
+    if (command === "toggle_selected") {
     	browser.tabs.query({active: true, currentWindow: true}, function(tabs){
-    		browser.tabs.sendMessage(tabs[0].id, {"message": "reveal_selected"});
+    		browser.tabs.sendMessage(tabs[0].id, {"message": "toggle_selected"});  
 		});
     }
 });

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Tahir",
   "description": "Avoid haram images & videos on the Internet.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "permissions": [
     "storage"
   ],
@@ -26,11 +26,11 @@
       },
       "description": "Reverse blur state"
     },
-    "unblur_selected": {
+    "toggle_selected": {
       "suggested_key": {
         "default": "Alt+K"
       },
-      "description": "Unblur selected image"
+      "description": "Unblur/reblur selected image"
     }
   },
   "background": {

--- a/firefox/popup.html
+++ b/firefox/popup.html
@@ -2,11 +2,11 @@
 <html>
   <head>
     <title>Tahir</title>
-    <script src="popup.js"></script>  
+    <script src="popup.js"></script>
     <style media="screen" type="text/css">
 
       .popup {
-        min-width:300px;
+        min-width:320px;
       }
 
       .title {
@@ -39,7 +39,7 @@
         left: 10px;
         height: 2px;
         color: #26ca28;
-        
+
       }
 
       .status:after {
@@ -51,7 +51,7 @@
         left: 35px;
         height: 2px;
         color: red;
-        
+
       }
 
       .status label {
@@ -73,7 +73,7 @@
       }
 
       .status input[type=checkbox] {
-          visibility: hidden; 
+          visibility: hidden;
         }
 
       .bluramt {
@@ -81,7 +81,7 @@
       }
 
       .images-videos-iframes {
-        margin-top: 4px; 
+        margin-top: 4px;
         margin-bottom: 4px;
       }
 
@@ -94,7 +94,7 @@
         font-size: 0.7rem;
       }
 
-    </style> 
+    </style>
   </head>
   <body class="popup">
 
@@ -108,10 +108,10 @@
     <div class="sub-title"><span>Settings</span></div>
 
     <div class="images-videos-iframes">
-      Images: <input type="checkbox" name="images" /> 
+      Images: <input type="checkbox" name="images" />
       BG Images: <input type="checkbox" name="bgimages" />
-      Videos: <input type="checkbox" name="videos" /> 
-      iFrames: <input type="checkbox" name="iframes" /> 
+      Videos: <input type="checkbox" name="videos" />
+      iFrames: <input type="checkbox" name="iframes" />
     </div>
 
     <div>
@@ -126,8 +126,8 @@
 
     <div class="shortcuts">
       <div><span>Alt+L: turn on / off </span></div>
-      <div><span>Alt+K: over image to selectively unblur (close this first)</span></div>
+      <div><span>Alt+K: over image to selectively unblur/reblur (close this first)</span></div>
     </div>
-    
+
   </body>
 </html>

--- a/firefox/popup.js
+++ b/firefox/popup.js
@@ -45,7 +45,7 @@ function initPopup () {
 /* getSettings - (1) Gets local storage settings, (2) sets local settings var to local storage settings, (3) resolves promise when complete  */
 function getSettings () {
   return new Promise(function(resolve) {
-      browser.storage.sync.get(['settings'], function(storage) {
+    browser.storage.sync.get(['settings'], function(storage) {
       settings = storage.settings
       resolve()
     });

--- a/firefox/tab.js
+++ b/firefox/tab.js
@@ -6,12 +6,6 @@
  *   - Listens to popup.js (popup modal) & background.js (key commands) for updates & modifies blur CSS as needed.
  *
  *
- *	Extension Features
- *		1. By default, all images, videos, iframes for all websites are blurred
- *		2. Selectively reveal an image, video, iframe.
- *		3. Turn off default blurring (via: popup, key command)
- *		4. Customize blurring (bluramt, grayscale, img, video, iframe)
- *
  */
 
 
@@ -60,7 +54,7 @@ function addListeners () {
 	browser.runtime.onMessage.addListener(
 	  function(request, sender, sendResponse) {
 	    if (request.message === 'reverse_status') { reverseStatus() }
-	    else if (request.message === 'reveal_selected') { revealSelected() }
+	    else if (request.message === 'toggle_selected') { toggleSelected() }
 	    else if (request.message.type === 'settings') { updateCSS(request.message) }
 	  }
 	);
@@ -95,7 +89,7 @@ function generateCssRules () {
 	if (settings.images === true) { cssRules += "img {filter: " + blurAmt + grayscale + "!important } "   }
 	if (settings.videos === true) { cssRules += "video {filter: " + blurAmt + grayscale + "!important } " }
 	if (settings.iframes === true) { cssRules += "iframe {filter: " + blurAmt + grayscale + "!important } " }
-	if (settings.bgImages === true) { cssRules += "div[style*='url'], span[style*='url'], a[style*='url'], i[style*='url'] {background-image: none !important; background-color: gray !important;}" }
+	if (settings.bgImages === true) { cssRules += "div[style*='url'], span[style*='url'], a[style*='url'], i[style*='url'] {filter: " + blurAmt + grayscale + "!important }" }
 
 	return cssRules
 }
@@ -118,28 +112,47 @@ function reverseStatus () {
 }
 
 
-/* revealSelected - Reveals blurred/hidden object under mouse hover */
-function revealSelected () {
+/* toggleSelected - (1) Determines objects over hover (2) reverses blur state of objects over hover  */
+function toggleSelected () {
 
-	/* Determine element user is clicking over */
+	/* Determine user hover */
 	const hover = document.querySelectorAll( ":hover" );
-	if (hover.length !== 0) {
-		var selected = hover[hover.length - 1]
-		while (selected.childNodes.length !== 0) {
-			selected = selected.childNodes[selected.childNodes.length - 1]
+
+	/* Iterate through all elements under hover. If any element is an (1) IMG, IFRAME, VIDEO or (2) has a in-line background-url --> toggle */
+	hover.forEach(function (selected, iterator, array) {
+		if (selected.nodeName === 'IMG' || selected.nodeName === 'IFRAME' || selected.nodeName === 'VIDEO') { toggle(selected) }
+		else if (selected.style.cssText.match(/url\(([^()]+)\)/)) { toggle(selected)}
+		//else if (getComputedStyle(selected).cssText.match(/url\(([^()]+)\)/)) {toggle(selected)} // this is for toggling objects that have a image in the CSS, not working well.
+	})
+
+	/* Toggle sub-method - adds forced blur or unblur as appropriate */
+	function toggle (selected) {
+		var cssText = selected.style.cssText
+
+		/* If image is blurred by default --> apply forced unblur */
+		if (settings.status === true && selected.style.filter === "") {
+			selected.style.cssText += ';filter: blur(0px) !important;'
+		}
+
+		/* If image is shown by default --> apply forced reblur */
+		else if (settings.status === false && selected.style.filter === "") {
+			var blurAmt = "blur(" + settings.blurAmt + "px) "
+			var grayscale = (settings.grayscale == true ? "grayscale(100%) " : "")
+			selected.style.cssText += ';filter: ' + blurAmt + grayscale + ' !important;'
+		}
+
+
+		/* If image has been force unblured, then force reblur */
+		else if (cssText.substr(cssText.length - 29) === "filter: blur(0px) !important;" ) {
+			var blurAmt = "blur(" + settings.blurAmt + "px) "
+			var grayscale = (settings.grayscale == true ? "grayscale(100%) " : "")
+			selected.style.cssText += ';filter: ' + blurAmt + grayscale + ' !important;'
+		}
+
+		/* If image has been forced reblured, then force unblur */
+		else {
+			selected.style.cssText += ';filter: blur(0px) !important;'
 		}
 	}
 
-	/* If element found, & is hidden element, reveal element: (1) if IMG, IFRAME, VIDEO --> set filter to blur 0px; (2) if DIV, SPAN, A, I --> append !important to background/background-image URL */
-	if (selected) {
-		if (selected.nodeName === 'IMG' || selected.nodeName === 'IFRAME' || selected.nodeName === 'VIDEO') { selected.style.cssText += ';filter: blur(0px) !important;' }
-		if (selected.nodeName === 'DIV' || selected.nodeName === 'SPAN' || selected.nodeName === 'A' || selected.nodeName === 'I') {
-			var hasURL = selected.style.cssText.match(/url\(([^()]+)\)/)
-			var hasImportant = selected.style.cssText.match(/url\(([^(]+)\) !important/)
-			if (hasURL && !hasImportant) {
-				var updatedCSS = selected.style.cssText.replace(/url\(([^()]+)\)/, '$&' + ' !important');
-				selected.style.cssText = updatedCSS
-			}
-		}
-	}
 }

--- a/firefox/update.html
+++ b/firefox/update.html
@@ -1,0 +1,49 @@
+<!doctype html>
+<html>
+
+<head>
+  <title>Tahir - Update (1.0.4)</title>
+  <style media="screen" type="text/css">
+    .main {
+      width: 50%;
+      margin-left: 25%;
+      border: 1px solid black;
+      padding: 10px;
+      font-size: 13px;
+    }
+
+    .title {
+      text-align: center;
+      margin-top: 20px;
+    }
+
+    .message {
+      margin-bottom: 15px;
+    }
+
+    .changelog {
+      margin-bottom: 100px;
+    }
+  </style>
+</head>
+
+<body>
+
+  <div class="main">
+    <h1 class="title">Tahir is updated! - Version 1.0.4</h1>
+    <div class="message">As salamu alaykum wa rahmatullah, <br/><br/> Below are the latest improvements for Tahir. We pray they are of benefit. If you like Tahir, please share with others (shareable links: <a href="https://twitter.com/intent/tweet?text=Check%20out%20Tahir!%20A%20chrome%20and%20firefox%20extension%20that%20automatically%20%22lowers%20your%20gaze%22%20on%20the%20web:%20https://chrome.google.com/webstore/detail/tahir/ihmoammkfbdpokfiiifajdkfglmfejca"
+        target="_blank">Twitter</a>, <a href="https://www.facebook.com/sharer/sharer.php?u=https://chrome.google.com/webstore/detail/tahir/ihmoammkfbdpokfiiifajdkfglmfejca" target="_blank">Facebook</a>). You will get reward for the haram images prevented
+      through your shares, iA. For support or comments, send us a message at dev@fushatech.com. To contribute to the code, see our <a href="https://github.com/fushatech/tahir" target="_blank">github</a>. <br/><br/> May Allah give us all tawfiq to protect
+      our eyes from the impermissible. </div>
+    <hr />
+    <h3>Changelog:</h3>
+    <ul class="changelog">
+      <li>Tahir is now <a href="https://addons.mozilla.org/en-US/firefox/addon/tahir/" target="_blank">available on Firefox.</a> (JAK to brother @sh4hids)</li>
+      <li>Alt+K now unblurs <strong>& reblurs an image</strong>. After unbluring an image, press Alt+K again to reblur it. </li>
+      <li>Several technical improvements.</li>
+    </ul>
+  </div>
+
+</body>
+
+</html>


### PR DESCRIPTION
- Alt-K now reblurs
- Alt-K method to unblur improved
- Alt-K adds unblur/reblur to entire hover sub-tree
- Updated method to blur BG images (now blurs, instead of setting background-color to gray)
- Created "update.html" which is opened in a new-tab on extension update.
- Added .gitignore file
- Updated manifest.json versioning to 1.0.4